### PR TITLE
Fix libdns::Record to dnsmadeeasy::Record translation

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -73,6 +73,8 @@ func createRecords(client dme.Client, zone string, records []libdns.Record) ([]l
 
 	var newRecords []libdns.Record
 	for _, dmeRec := range newDmeRecords {
+		// The client.CreateRecords call wraps the value in spurious quotes
+		dmeRec.Value = dmeRec.Value[1 : len(dmeRec.Value)-1]
 		newRec := recordFromDmeRecord(dmeRec)
 		newRecords = append(newRecords, newRec)
 	}

--- a/provider.go
+++ b/provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 
 	dme "github.com/john-k/dnsmadeeasy"
@@ -74,7 +75,7 @@ func createRecords(client dme.Client, zone string, records []libdns.Record) ([]l
 	var newRecords []libdns.Record
 	for _, dmeRec := range newDmeRecords {
 		// The client.CreateRecords call wraps the value in spurious quotes
-		dmeRec.Value = dmeRec.Value[1 : len(dmeRec.Value)-1]
+		dmeRec.Value = strings.Trim(dmeRec.Value, "\"")
 		newRec := recordFromDmeRecord(dmeRec)
 		newRecords = append(newRecords, newRec)
 	}


### PR DESCRIPTION
I'm not sure when DNSMadeEasy tweaked their API, but there are now several incompatibilities with the module as it exists.  Specifically:

1. The CreateRecords call now returns the value of the created record wrapped in spurious/non-existent quotes (see #3).  This removes them.
2. DNSMadeEasy no longer accepts a TTL of 0 (which certmagic passes us by default unless it's set specifically), so `dmeRecordFromRecord` will now set a default value of 120 if the value is 0.
3. Similarly, they require a value to be set for `GtdLocation` from the possible values `DEFAULT, US_EAST, US_WEST, EUROPE, ASIA_PAC, OCREANIA, SOUTH_AMERICA`.  We set it to `DEFAULT`.
4. Finally, if we get passed a blank string for `record.ID`, we translate it to 0 in the dmeRecord struct, so it will properly be omitted thanks to the `json:"id,omitempty"` tag on the dmeRecord.ID item.